### PR TITLE
Line splitting

### DIFF
--- a/Source/StevesUEHelpers/Private/StevesUI/TypewriterTextWidget.cpp
+++ b/Source/StevesUEHelpers/Private/StevesUI/TypewriterTextWidget.cpp
@@ -120,11 +120,9 @@ void UTypewriterTextWidget::PlayNextLinePart(float Speed)
 
 		CalculateWrappedString(RemainingLinePart);
 
-		// TODO Jonas: Promote MaxLines to variable. Might want MaxLines = 1 for text before choices.
-		int MaxLines = 3;
-		if (NumberOfLines > MaxLines)
+		if (NumberOfLines > MaxNumberOfLines)
 		{
-			int MaxLength = CalculateMaxLength(MaxLines);
+			int MaxLength = CalculateMaxLength();
 			int TerminatorIndex = FindLastTerminator(RemainingLinePart, MaxLength);
 			int Length = TerminatorIndex + 1;
 			const FString& FirstLinePart = RemainingLinePart.Left(Length);
@@ -236,14 +234,13 @@ int UTypewriterTextWidget::FindLastTerminator(const FString& CurrentLineString, 
 	return (Count - 1);
 }
 
-int UTypewriterTextWidget::CalculateMaxLength(int MaxNumberOfLines)
+int UTypewriterTextWidget::CalculateMaxLength()
 {
 	int MaxLength = 0;
 	int CurrentNumberOfLines = 1;
 	for (int i = 0; i < Segments.Num(); i++)
 	{
 		const FTypewriterTextSegment& Segment = Segments[i];
-		// TODO Jonas: Mark line break segments as such in CalculateWrappedString instead.
 		if (Segment.Text.Equals(FString(TEXT("\n"))))
 		{
 			CurrentNumberOfLines++;

--- a/Source/StevesUEHelpers/Private/StevesUI/TypewriterTextWidget.cpp
+++ b/Source/StevesUEHelpers/Private/StevesUI/TypewriterTextWidget.cpp
@@ -208,16 +208,32 @@ bool UTypewriterTextWidget::IsSentenceTerminator(TCHAR Letter)
 	return Letter == '.' || Letter == '!' || Letter == '?';
 }
 
+bool UTypewriterTextWidget::IsClauseTerminator(TCHAR Letter)
+{
+	return Letter == ',' || Letter == ';';
+}
+
 int UTypewriterTextWidget::FindLastTerminator(const FString& CurrentLineString, int Count)
 {
-	// TODO Jonas: Find lesser terminators like commas or spaces if no sentence terminator can be found.
 	int TerminatorIndex = CurrentLineString.FindLastCharByPredicate(IsSentenceTerminator, Count);
 	if (TerminatorIndex != INDEX_NONE)
 	{
 		return TerminatorIndex;
 	}
 
-	return Count;
+	TerminatorIndex = CurrentLineString.FindLastCharByPredicate(IsClauseTerminator, Count);
+	if (TerminatorIndex != INDEX_NONE)
+	{
+		return TerminatorIndex;
+	}
+
+	TerminatorIndex = CurrentLineString.FindLastCharByPredicate(FText::IsWhitespace, Count);
+	if (TerminatorIndex != INDEX_NONE)
+	{
+		return TerminatorIndex;
+	}
+
+	return (Count - 1);
 }
 
 int UTypewriterTextWidget::CalculateMaxLength(int MaxNumberOfLines)

--- a/Source/StevesUEHelpers/Private/StevesUI/TypewriterTextWidget.cpp
+++ b/Source/StevesUEHelpers/Private/StevesUI/TypewriterTextWidget.cpp
@@ -42,7 +42,6 @@ TSharedRef<SWidget> URichTextBlockForTypewriter::RebuildWidget()
 UTypewriterTextWidget::UTypewriterTextWidget(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)
 {
-	bHasMoreLineParts = false;
 	bHasFinishedPlaying = true;
 }
 
@@ -55,7 +54,6 @@ void UTypewriterTextWidget::SetText(const FText& InText)
 		
 		LineText->SetText(InText);
 
-		bHasMoreLineParts = false;
 		bHasFinishedPlaying = true;
 	}
 }
@@ -102,7 +100,6 @@ void UTypewriterTextWidget::PlayNextLinePart(float Speed)
 			LineText->SetText(FText::GetEmpty());
 		}
 
-		bHasMoreLineParts = false;
 		bHasFinishedPlaying = true;
 		OnTypewriterLineFinished.Broadcast(this);
 		OnLineFinishedPlaying();
@@ -165,7 +162,7 @@ void UTypewriterTextWidget::PlayNextLinePart(float Speed)
 
 				CalculateWrappedString(shortenedString);
 
-				RemainingLinePart.RightInline(count);
+				RemainingLinePart.RightChopInline(count);
 				bHasMoreLineParts = true;
 			}
 		}
@@ -190,16 +187,9 @@ void UTypewriterTextWidget::SkipToLineEnd()
 		LineText->SetText(FText::FromString(CalculateSegments(nullptr)));
 	}
 
-	if (bHasMoreLineParts)
-	{
-		OnTypewriterLinePartFinished.Broadcast(this);
-	}
-	else
-	{
-		bHasFinishedPlaying = true;
-		OnTypewriterLineFinished.Broadcast(this);
-		OnLineFinishedPlaying();
-	}
+	bHasFinishedPlaying = true;
+	OnTypewriterLineFinished.Broadcast(this);
+	OnLineFinishedPlaying();
 }
 
 void UTypewriterTextWidget::PlayNextLetter()

--- a/Source/StevesUEHelpers/Private/StevesUI/TypewriterTextWidget.cpp
+++ b/Source/StevesUEHelpers/Private/StevesUI/TypewriterTextWidget.cpp
@@ -118,9 +118,9 @@ void UTypewriterTextWidget::PlayNextLinePart(float Speed)
 
 		LineText->SetText(FText());
 
-		const FString& currentLineString = RemainingLinePart;
-		CalculateWrappedString(currentLineString);
+		CalculateWrappedString(RemainingLinePart);
 
+		// TODO Jonas: Promote maxLines to variable. Might want maxLines = 1 for text before choices.
 		int maxLines = 3;
 		if (NumberOfLines > maxLines)
 		{
@@ -129,6 +129,7 @@ void UTypewriterTextWidget::PlayNextLinePart(float Speed)
 			for (int i = 0; i < Segments.Num(); i++)
 			{
 				const auto& segment = Segments[i];
+				// TODO Jonas: Mark line break segments in CalculateWrappedString instead.
 				if (segment.Text.Equals(FString(TEXT("\n"))))
 				{
 					currentLine++;
@@ -143,12 +144,14 @@ void UTypewriterTextWidget::PlayNextLinePart(float Speed)
 				}
 			}
 
-			int lastTerminator = currentLineString.FindLastCharByPredicate(IsSentenceTerminator, numLetters);
+			// TODO Jonas: Find lesser terminators like commas or spaces if no sentence terminator can be found.
+			int lastTerminator = RemainingLinePart.FindLastCharByPredicate(IsSentenceTerminator, numLetters);
 			if (lastTerminator != INDEX_NONE)
 			{
 				int count = lastTerminator + 1;
-				const FString& shortenedString = currentLineString.Left(count);
+				const FString& shortenedString = RemainingLinePart.Left(count);
 
+				// TODO Jonas: Clean up
 				CurrentRunName = "";
 				CurrentLetterIndex = 0;
 				CachedLetterIndex = 0;

--- a/Source/StevesUEHelpers/Private/StevesUI/TypewriterTextWidget.cpp
+++ b/Source/StevesUEHelpers/Private/StevesUI/TypewriterTextWidget.cpp
@@ -134,20 +134,20 @@ void UTypewriterTextWidget::PlayNextLinePart(float Speed)
 
 void UTypewriterTextWidget::StartPlayLine()
 {
-		CalculateWrappedString(RemainingLinePart);
+	CalculateWrappedString(RemainingLinePart);
 
-		if (NumberOfLines > MaxNumberOfLines)
-		{
-			int MaxLength = CalculateMaxLength();
-			int TerminatorIndex = FindLastTerminator(RemainingLinePart, MaxLength);
-			int Length = TerminatorIndex + 1;
-			const FString& FirstLinePart = RemainingLinePart.Left(Length);
+	if (NumberOfLines > MaxNumberOfLines)
+	{
+		int MaxLength = CalculateMaxLength();
+		int TerminatorIndex = FindLastTerminator(RemainingLinePart, MaxLength);
+		int Length = TerminatorIndex + 1;
+		const FString& FirstLinePart = RemainingLinePart.Left(Length);
 
-			CalculateWrappedString(FirstLinePart);
+		CalculateWrappedString(FirstLinePart);
 
-			RemainingLinePart.RightChopInline(Length);
-			bHasMoreLineParts = true;
-		}
+		RemainingLinePart.RightChopInline(Length);
+		bHasMoreLineParts = true;
+	}
 		
 	FTimerDelegate Delegate;
 	Delegate.BindUObject(this, &ThisClass::PlayNextLetter);

--- a/Source/StevesUEHelpers/Private/StevesUI/TypewriterTextWidget.cpp
+++ b/Source/StevesUEHelpers/Private/StevesUI/TypewriterTextWidget.cpp
@@ -153,6 +153,11 @@ void UTypewriterTextWidget::PlayLine(const FText& InLine, float Speed)
 				CachedSegmentText.Empty();
 
 				CalculateWrappedString(shortenedString);
+
+				// TODO Jonas: Play remaining line after the shortened string.
+				// If this is done purely in the typewriter then advancing the dialog would
+				// skip over all but the last part of the text. Alternatively advancing has
+				// to get rerouted to trigger a dialogue action only for the last part.
 			}
 		}
 		

--- a/Source/StevesUEHelpers/Public/StevesUI/TypewriterTextWidget.h
+++ b/Source/StevesUEHelpers/Public/StevesUI/TypewriterTextWidget.h
@@ -131,7 +131,9 @@ protected:
 private:
 	void PlayNextLetter();
 	static bool IsSentenceTerminator(TCHAR Letter);
+	static int FindLastTerminator(const FString& CurrentLineString, int Count);
 
+	int CalculateMaxLength(int MaxNumberOfLines);
 	void CalculateWrappedString(const FString& CurrentLineString);
 	FString CalculateSegments(FString* OutCurrentRunName);
 

--- a/Source/StevesUEHelpers/Public/StevesUI/TypewriterTextWidget.h
+++ b/Source/StevesUEHelpers/Public/StevesUI/TypewriterTextWidget.h
@@ -126,7 +126,7 @@ private:
 	void PlayNextLetter();
 	static bool IsSentenceTerminator(TCHAR Letter);
 
-	void CalculateWrappedString();
+	void CalculateWrappedString(const FString& CurrentLineString);
 	FString CalculateSegments(FString* OutCurrentRunName);
 
 	UPROPERTY()

--- a/Source/StevesUEHelpers/Public/StevesUI/TypewriterTextWidget.h
+++ b/Source/StevesUEHelpers/Public/StevesUI/TypewriterTextWidget.h
@@ -131,6 +131,7 @@ protected:
 private:
 	void PlayNextLetter();
 	static bool IsSentenceTerminator(TCHAR Letter);
+	static bool IsClauseTerminator(TCHAR Letter);
 	static int FindLastTerminator(const FString& CurrentLineString, int Count);
 
 	int CalculateMaxLength(int MaxNumberOfLines);

--- a/Source/StevesUEHelpers/Public/StevesUI/TypewriterTextWidget.h
+++ b/Source/StevesUEHelpers/Public/StevesUI/TypewriterTextWidget.h
@@ -56,6 +56,10 @@ class STEVESUEHELPERS_API UTypewriterTextWidget : public UUserWidget
 public:
 	UTypewriterTextWidget(const FObjectInitializer& ObjectInitializer);
 
+	/// Event called when a line part has finished playing, whether on its own or when skipped to end
+	UPROPERTY(BlueprintAssignable)
+	FOnTypewriterLineFinished OnTypewriterLinePartFinished;
+
 	/// Event called when a line has finished playing, whether on its own or when skipped to end
 	UPROPERTY(BlueprintAssignable)
 	FOnTypewriterLineFinished OnTypewriterLineFinished;
@@ -103,6 +107,9 @@ public:
 	bool HasFinishedPlayingLine() const { return bHasFinishedPlaying; }
 
 	UFUNCTION(BlueprintCallable, Category = "Typewriter")
+	void PlayNextLinePart(float Speed = 1.0f);
+
+	UFUNCTION(BlueprintCallable, Category = "Typewriter")
 	void SkipToLineEnd();
 
 	/// Get the name of the current rich text run, if any
@@ -132,7 +139,7 @@ private:
 	UPROPERTY()
 	FText CurrentLine;
 
-	
+	FString RemainingLinePart;
 
 	struct FTypewriterTextSegment
 	{
@@ -155,6 +162,7 @@ private:
 	float CombinedTextHeight = 0;
 
 	uint32 bHasFinishedPlaying : 1;
+	uint32 bHasMoreLineParts : 1;
 
 	FTimerHandle LetterTimer;
 	float CurrentPlaySpeed = 1;

--- a/Source/StevesUEHelpers/Public/StevesUI/TypewriterTextWidget.h
+++ b/Source/StevesUEHelpers/Public/StevesUI/TypewriterTextWidget.h
@@ -84,6 +84,10 @@ public:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Typewriter")
 	float PauseTimeAtSentenceTerminators = 0.5f;
 
+	/// How many lines of text at most to print at once.
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Typewriter")
+	int MaxNumberOfLines = 3;
+
 	/// Set Text immediately
 	UFUNCTION(BlueprintCallable)
 	void SetText(const FText& InText);
@@ -134,7 +138,7 @@ private:
 	static bool IsClauseTerminator(TCHAR Letter);
 	static int FindLastTerminator(const FString& CurrentLineString, int Count);
 
-	int CalculateMaxLength(int MaxNumberOfLines);
+	int CalculateMaxLength();
 	void CalculateWrappedString(const FString& CurrentLineString);
 	FString CalculateSegments(FString* OutCurrentRunName);
 

--- a/Source/StevesUEHelpers/Public/StevesUI/TypewriterTextWidget.h
+++ b/Source/StevesUEHelpers/Public/StevesUI/TypewriterTextWidget.h
@@ -56,10 +56,6 @@ class STEVESUEHELPERS_API UTypewriterTextWidget : public UUserWidget
 public:
 	UTypewriterTextWidget(const FObjectInitializer& ObjectInitializer);
 
-	/// Event called when a line part has finished playing, whether on its own or when skipped to end
-	UPROPERTY(BlueprintAssignable)
-	FOnTypewriterLineFinished OnTypewriterLinePartFinished;
-
 	/// Event called when a line has finished playing, whether on its own or when skipped to end
 	UPROPERTY(BlueprintAssignable)
 	FOnTypewriterLineFinished OnTypewriterLineFinished;
@@ -105,6 +101,9 @@ public:
 
 	UFUNCTION(BlueprintCallable, Category = "Typewriter")
 	bool HasFinishedPlayingLine() const { return bHasFinishedPlaying; }
+
+	UFUNCTION(BlueprintCallable, Category = "Typewriter")
+	bool HasMoreLineParts() const { return bHasMoreLineParts; }
 
 	UFUNCTION(BlueprintCallable, Category = "Typewriter")
 	void PlayNextLinePart(float Speed = 1.0f);


### PR DESCRIPTION
Breaking overly long lines of text into multiple parts to avoid overflowing the text widget.